### PR TITLE
Driver return share hot and cold capacity as long as manila deliver hot_data_size or cold_data_size when create share

### DIFF
--- a/Manila/file_driver_dir/huawei/oceanstorPacific/plugin/suyan_gfs/suyan_gfs_share_tier.py
+++ b/Manila/file_driver_dir/huawei/oceanstorPacific/plugin/suyan_gfs/suyan_gfs_share_tier.py
@@ -81,15 +81,17 @@ class SuyanGfsShareTier(ShareTier):
             'name_locator': name_locator
         })
         if len(migrate_policy) <= 0:
-            LOG.info(_("migrate_policy {0} not found".format(name_locator)))
+            LOG.warning("migrate_policy %s not found, return {}", name_locator)
             return {}
         policy = migrate_policy[0]
-        return {
+        share_tier_status = {
             "tier_status": self._dme_policy_status_to_enum_num(policy.get("policy_status")),
             "tier_process": policy.get("migration_percent"),
             "tier_type": self._dme_tier_grade_to_enum_suyan_str(policy.get("tier_grade")),
             "tier_path": policy.get("file_name_filter", {}).get("filter")
         }
+        LOG.debug("Get share tier status:%s successfully", share_tier_status)
+        return share_tier_status
 
     def terminate_share_tier(self):
         name_locator_info = self._combine_name_locator()

--- a/Manila/file_driver_dir/huawei/oceanstorPacific/plugin/suyan_single/suyan_single_check_update_storage.py
+++ b/Manila/file_driver_dir/huawei/oceanstorPacific/plugin/suyan_single/suyan_single_check_update_storage.py
@@ -37,17 +37,19 @@ class SuyanSingleCheckUpdateStorage(CommunityCheckUpdateStorage):
     @staticmethod
     def _check_and_set_tier_quota(namespace_info, all_share_usages, name_key):
         namespace_name = namespace_info.get(name_key)
-        if not namespace_info.get('tier_hot_cap_limit'):
-            LOG.info("Namespace %s not set hot_data_size, don't return ssd and hhd "
-                     "capacity", namespace_name)
+        used_key = 'used'
+        tier_hot_cap_limit = namespace_info.get('tier_hot_cap_limit')
+        tier_cold_cap_limit = namespace_info.get('tier_cold_cap_limit')
+        if tier_hot_cap_limit is None and tier_cold_cap_limit is None:
             return all_share_usages
+
         ssd_hard_quota = driver_utils.capacity_unit_up_conversion(
-                    namespace_info.get('tier_hot_cap_limit'), constants.BASE_VALUE, 1)
+                    tier_hot_cap_limit, constants.BASE_VALUE, 1)
         hdd_hard_quota = driver_utils.capacity_unit_up_conversion(
-                    namespace_info.get('tier_cold_cap_limit'), constants.BASE_VALUE, 1)
+                    tier_cold_cap_limit, constants.BASE_VALUE, 1)
         tier_perf_cap = json.loads(namespace_info.get('tier_perf_cap', '{}'))
-        ssd_space_used = tier_perf_cap.get('hot', {}).get('used', 0)
-        hdd_space_used = tier_perf_cap.get('cold', {}).get('used', 0)
+        ssd_space_used = tier_perf_cap.get('hot', {}).get(used_key)
+        hdd_space_used = tier_perf_cap.get('cold', {}).get(used_key)
         all_share_usages.get(namespace_name).update(
             {
                 'ssd_hard_quota': ssd_hard_quota,

--- a/Manila/file_driver_dir/huawei/oceanstorPacific/plugin/suyan_single/suyan_single_operate_share.py
+++ b/Manila/file_driver_dir/huawei/oceanstorPacific/plugin/suyan_single/suyan_single_operate_share.py
@@ -284,6 +284,7 @@ class SuyanSingleOperateShare(CommunityOperateShare):
             dpc_path = self._get_dpc_path('/' + share_path)
             location.append('DPC:' + dpc_path)
 
+        LOG.info("Create share successfully, the location of this share is %s", location)
         return location
 
     def _get_dtree_namespace_info(self):
@@ -314,6 +315,7 @@ class SuyanSingleOperateShare(CommunityOperateShare):
             share_info = share_usages.get(self.namespace_name)
 
         if not share_info:
+            LOG.info("Can not find share in share_usages. return {}")
             return {}
 
         return self._check_and_get_share_capacity(share_info)

--- a/Manila/file_driver_dir/huawei/oceanstorPacific/plugin/suyan_single/suyan_single_share_tier.py
+++ b/Manila/file_driver_dir/huawei/oceanstorPacific/plugin/suyan_single/suyan_single_share_tier.py
@@ -124,16 +124,18 @@ class SuyanSingleShareTier(ShareTier):
 
         if not migrate_policy:
             # 不存在分级策略报错
-            LOG.info(_("migrate_policy {0} for fs {1} not found"
-                       .format(migrate_policy_name, namespace_name)))
+            LOG.warning("migrate_policy %s for fs %s not found, return {}",
+                        migrate_policy_name, namespace_name)
             return {}
-        else:
-            return {
-                "tier_status": migrate_policy.get("policy_status"),
-                "tier_process": migrate_policy.get("migration_percent"),
-                "tier_type": self._pacific_tier_grade_to_enum_suyan_str(migrate_policy.get("strategy")),
-                "tier_path": migrate_policy.get("path_name")
-            }
+        share_tier_status = {
+            "tier_status": migrate_policy.get("policy_status"),
+            "tier_process": migrate_policy.get("migration_percent"),
+            "tier_type": self._pacific_tier_grade_to_enum_suyan_str(
+                migrate_policy.get("strategy")),
+            "tier_path": migrate_policy.get("path_name")
+        }
+        LOG.debug("Get share tier status:%s successfully", share_tier_status)
+        return share_tier_status
 
     def terminate_share_tier(self):
         self._get_account_id()

--- a/Manila/file_driver_dir/huawei/oceanstorPacific/utils/constants.py
+++ b/Manila/file_driver_dir/huawei/oceanstorPacific/utils/constants.py
@@ -172,6 +172,7 @@ USED_CAPACITY_ENUM = {
     DISK_TYPE_SAS: SAS_USED_CAP_KEY,
     DISK_TYPE_SATA: SATA_USED_CAP_KEY
 }
+SUPPORT_TIER_PLACE = ['hot', 'cold']
 DISK_POOL_TIER_ENUM = {
     '0': 'warm',
     '1': 'hot',

--- a/Manila/file_driver_dir/huawei/oceanstorPacific/utils/driver_config.py
+++ b/Manila/file_driver_dir/huawei/oceanstorPacific/utils/driver_config.py
@@ -133,7 +133,7 @@ class DriverConfig(object):
 
     def _nas_storage_pools(self, xml_root):
         text = xml_root.findtext('Filesystem/StoragePool')
-        self.check_config_exist(text, 'Storage/StoragePool')
+        self.check_config_exist(text, 'Filesystem/StoragePool')
 
         if self.config.product == constants.PRODUCT_PACIFIC:
             pool_is_digit_list = [pool_id.strip().isdigit() for pool_id in text.split(';')]


### PR DESCRIPTION

When the capacity is reported, if the hot_data_size or cold_data_size is setted, the tiered capacity needs to be reported when manila call get_share_usage method.